### PR TITLE
Plates can now be sold

### DIFF
--- a/src/Services/Catalog/Catalog.API/Controllers/PlatesController.cs
+++ b/src/Services/Catalog/Catalog.API/Controllers/PlatesController.cs
@@ -22,7 +22,7 @@ public class PlatesController : Controller
 			(orderAscending ? dbContext.Plates.OrderBy(SortBy(orderBy)) : dbContext.Plates.OrderByDescending(SortBy(orderBy)))
 			.ThenBy(x => x.Id)
 			.Where(FilterBy(age, initials))
-			.Where(x => !x.IsReserved)
+			.Where(x => x.Status != PlateStatus.Reserved)
 			.Skip(page * NUMBER_OF_PLATES)
 			.Take(NUMBER_OF_PLATES)
 			.Select(x => new
@@ -30,7 +30,7 @@ public class PlatesController : Controller
 				Registration = x.Registration,
 				PurchasePrice = x.PurchasePrice,
 				SalePrice = x.CalculateSalesPrice(discountCode),
-				Reserved = x.IsReserved,
+				Status = x.Status,
 			});
 
 		return Ok(plates);
@@ -43,10 +43,10 @@ public class PlatesController : Controller
 		if (plate == default)
 			return BadRequest("Plate doesn't exist");
 
-		if (plate.IsReserved)
+		if (plate.Status == PlateStatus.Reserved)
 			return BadRequest("Plate is already reserved");
 
-		plate.IsReserved = true;
+		plate.Status = PlateStatus.Reserved;
 
 		try
 		{

--- a/src/Services/Catalog/Catalog.API/Controllers/PlatesController.cs
+++ b/src/Services/Catalog/Catalog.API/Controllers/PlatesController.cs
@@ -46,6 +46,9 @@ public class PlatesController : Controller
 		if (plate.Status == PlateStatus.Reserved)
 			return BadRequest("Plate is already reserved");
 
+		if (plate.Status == PlateStatus.Sold)
+			return BadRequest("Plate is already sold");
+
 		plate.Status = PlateStatus.Reserved;
 
 		try
@@ -55,6 +58,31 @@ public class PlatesController : Controller
 		catch (Exception ex)
 		{
 			Log.Logger.Error(ex, "Failed to reserve plate");
+			return BadRequest("Failed to update record");
+		}
+
+		return Ok();
+	}
+
+	[HttpPatch("PurchasePlate")]
+	public async Task<IActionResult> PurchasePlate(Guid plateId)
+	{
+		var plate = dbContext.Plates.FirstOrDefault(x => x.Id == plateId);
+		if (plate == default)
+			return BadRequest("Plate doesn't exist");
+
+		if (plate.Status == PlateStatus.Sold)
+			return BadRequest("Plate is already sold");
+
+		plate.Status = PlateStatus.Sold;
+
+		try
+		{
+			await dbContext.SaveChangesAsync();
+		}
+		catch (Exception ex)
+		{
+			Log.Logger.Error(ex, "Failed to sell plate");
 			return BadRequest("Failed to update record");
 		}
 

--- a/src/Services/Catalog/Catalog.API/Data/Migrations/20240611101117_Sold.Designer.cs
+++ b/src/Services/Catalog/Catalog.API/Data/Migrations/20240611101117_Sold.Designer.cs
@@ -4,6 +4,7 @@ using Catalog.API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Catalog.API.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240611101117_Sold")]
+    partial class Sold
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Services/Catalog/Catalog.API/Data/Migrations/20240611101117_Sold.cs
+++ b/src/Services/Catalog/Catalog.API/Data/Migrations/20240611101117_Sold.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Catalog.API.Migrations
+{
+    public partial class Sold : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsReserved",
+                table: "Plates");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Status",
+                table: "Plates",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Plates");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsReserved",
+                table: "Plates",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/src/Services/Catalog/Catalog.Domain/Plate.cs
+++ b/src/Services/Catalog/Catalog.Domain/Plate.cs
@@ -14,7 +14,7 @@
 
 		public int Numbers { get; set; }
 
-		public bool IsReserved { get; set; }
+		public PlateStatus Status { get; set; }
 
 
 		public decimal CalculateSalesPrice(string discountCode = "")
@@ -32,5 +32,12 @@
 
 			return salePrice;
 		}
+	}
+
+	public enum PlateStatus
+	{
+		Available,
+		Reserved,
+		Sold
 	}
 }

--- a/src/Services/Catalog/Catalog.UnitTests/PlatesController.cs
+++ b/src/Services/Catalog/Catalog.UnitTests/PlatesController.cs
@@ -564,6 +564,58 @@ namespace Catalog.UnitTests
 			Assert.Equal("Plate is already reserved", badRequestResult.Value);
 		}
 
+		[Fact]
+		public async void ReservePlate_AlreadySold()
+		{
+			var plateId = Guid.Parse("0812851E-3EC3-4D12-BAF6-C9F0E6DC2F76");
+
+			// Initialize a list of MyEntity objects to back the DbSet with.
+			var myEntities = new List<Domain.Plate>()
+			{
+				new Domain.Plate() {
+					Id = plateId,
+					Registration = "T44GUE",
+					PurchasePrice = 2722.51m,
+					SalePrice = 8995.00m,
+					Numbers = 44,
+					Letters = "TAG",
+					Status = PlateStatus.Sold,
+			}, new Domain.Plate() {
+					Id = Guid.Parse("DF81D7FC-319B-46A8-AB66-2574B4169C3D"),
+					Registration = "M44BEY",
+					PurchasePrice = 859.10m,
+					SalePrice = 8995.00m,
+					Numbers = 44,
+					Letters = "MAB"
+			}, new Domain.Plate() {
+					Id = Guid.Parse("0E9C83BF-94E2-484A-97CB-A8B06E3410FD"),
+					Registration = "P777PER",
+					PurchasePrice = 1494.08m,
+					SalePrice = 4995.00m,
+					Numbers = 777,
+					Letters = "PYP"
+				}
+			};
+
+			// Create a mock DbContext.
+			var dbContext = new Mock<ApplicationDbContext>();
+
+			// Create a mock DbSet.
+			var dbSet = MockDbSetFactory.Create(myEntities);
+
+			// Set up the MyEntities property so it returns the mocked DbSet.
+			dbContext.Setup(o => o.Plates).Returns(dbSet.Object);
+
+			var platesController = new Catalog.API.Controllers.PlatesController(dbContext.Object);
+
+			var actualResult = await platesController.ReservePlate(plateId);
+
+			// assert
+			var badRequestResult = Assert.IsType<BadRequestObjectResult>(actualResult);
+			Assert.Equal(400, badRequestResult.StatusCode);
+			Assert.Equal("Plate is already sold", badRequestResult.Value);
+		}
+
 		[InlineData("0812851E-3EC3-4D12-BAF6-C9F0E6DC2F76")]
 		[InlineData("DF81D7FC-319B-46A8-AB66-2574B4169C3D")]
 		[InlineData("0E9C83BF-94E2-484A-97CB-A8B06E3410FD")]
@@ -615,6 +667,160 @@ namespace Catalog.UnitTests
 			var okResult = Assert.IsType<OkResult>(actualResult);
 			Assert.Equal(200, okResult.StatusCode);
 			
+		}
+
+		[Fact]
+		public async void PurchasePlate_NotFound()
+		{
+			// Initialize a list of MyEntity objects to back the DbSet with.
+			var myEntities = new List<Domain.Plate>()
+			{
+				new Domain.Plate() {
+					Id = Guid.Parse("0812851E-3EC3-4D12-BAF6-C9F0E6DC2F76"),
+					Registration = "T44GUE",
+					PurchasePrice = 2722.51m,
+					SalePrice = 8995.00m,
+					Numbers = 44,
+					Letters = "TAG"
+			}, new Domain.Plate() {
+					Id = Guid.Parse("DF81D7FC-319B-46A8-AB66-2574B4169C3D"),
+					Registration = "M44BEY",
+					PurchasePrice = 859.10m,
+					SalePrice = 8995.00m,
+					Numbers = 44,
+					Letters = "MAB"
+			}, new Domain.Plate() {
+					Id = Guid.Parse("0E9C83BF-94E2-484A-97CB-A8B06E3410FD"),
+					Registration = "P777PER",
+					PurchasePrice = 1494.08m,
+					SalePrice = 4995.00m,
+					Numbers = 777,
+					Letters = "PYP"
+				}
+			};
+
+			// Create a mock DbContext.
+			var dbContext = new Mock<ApplicationDbContext>();
+
+			// Create a mock DbSet.
+			var dbSet = MockDbSetFactory.Create(myEntities);
+
+			// Set up the MyEntities property so it returns the mocked DbSet.
+			dbContext.Setup(o => o.Plates).Returns(dbSet.Object);
+
+			var platesController = new Catalog.API.Controllers.PlatesController(dbContext.Object);
+
+			var actualResult = await platesController.PurchasePlate(Guid.NewGuid());
+
+			// assert
+			var badRequestResult = Assert.IsType<BadRequestObjectResult>(actualResult);
+			Assert.Equal(400, badRequestResult.StatusCode);
+			Assert.Equal("Plate doesn't exist", badRequestResult.Value);
+		}
+
+		[Fact]
+		public async void PurchasePlate_AlreadySold()
+		{
+			var plateId = Guid.Parse("0812851E-3EC3-4D12-BAF6-C9F0E6DC2F76");
+
+			// Initialize a list of MyEntity objects to back the DbSet with.
+			var myEntities = new List<Domain.Plate>()
+			{
+				new Domain.Plate() {
+					Id = plateId,
+					Registration = "T44GUE",
+					PurchasePrice = 2722.51m,
+					SalePrice = 8995.00m,
+					Numbers = 44,
+					Letters = "TAG",
+					Status = PlateStatus.Sold,
+			}, new Domain.Plate() {
+					Id = Guid.Parse("DF81D7FC-319B-46A8-AB66-2574B4169C3D"),
+					Registration = "M44BEY",
+					PurchasePrice = 859.10m,
+					SalePrice = 8995.00m,
+					Numbers = 44,
+					Letters = "MAB"
+			}, new Domain.Plate() {
+					Id = Guid.Parse("0E9C83BF-94E2-484A-97CB-A8B06E3410FD"),
+					Registration = "P777PER",
+					PurchasePrice = 1494.08m,
+					SalePrice = 4995.00m,
+					Numbers = 777,
+					Letters = "PYP"
+				}
+			};
+
+			// Create a mock DbContext.
+			var dbContext = new Mock<ApplicationDbContext>();
+
+			// Create a mock DbSet.
+			var dbSet = MockDbSetFactory.Create(myEntities);
+
+			// Set up the MyEntities property so it returns the mocked DbSet.
+			dbContext.Setup(o => o.Plates).Returns(dbSet.Object);
+
+			var platesController = new Catalog.API.Controllers.PlatesController(dbContext.Object);
+
+			var actualResult = await platesController.PurchasePlate(plateId);
+
+			// assert
+			var badRequestResult = Assert.IsType<BadRequestObjectResult>(actualResult);
+			Assert.Equal(400, badRequestResult.StatusCode);
+			Assert.Equal("Plate is already sold", badRequestResult.Value);
+		}
+
+		[InlineData("0812851E-3EC3-4D12-BAF6-C9F0E6DC2F76")]
+		[InlineData("DF81D7FC-319B-46A8-AB66-2574B4169C3D")]
+		[InlineData("0E9C83BF-94E2-484A-97CB-A8B06E3410FD")]
+		[Theory]
+		public async void PurchasePlate_Update(string id)
+		{
+			var plateId = Guid.Parse(id);
+			// Initialize a list of MyEntity objects to back the DbSet with.
+			var myEntities = new List<Domain.Plate>()
+			{
+				new Domain.Plate() {
+					Id = Guid.Parse("0812851E-3EC3-4D12-BAF6-C9F0E6DC2F76"),
+					Registration = "T44GUE",
+					PurchasePrice = 2722.51m,
+					SalePrice = 8995.00m,
+					Numbers = 44,
+					Letters = "TAG"
+			}, new Domain.Plate() {
+					Id = Guid.Parse("DF81D7FC-319B-46A8-AB66-2574B4169C3D"),
+					Registration = "M44BEY",
+					PurchasePrice = 859.10m,
+					SalePrice = 8995.00m,
+					Numbers = 44,
+					Letters = "MAB"
+			}, new Domain.Plate() {
+					Id = Guid.Parse("0E9C83BF-94E2-484A-97CB-A8B06E3410FD"),
+					Registration = "P777PER",
+					PurchasePrice = 1494.08m,
+					SalePrice = 4995.00m,
+					Numbers = 777,
+					Letters = "PYP",
+					Status = PlateStatus.Reserved
+				}
+			};
+
+			// Create a mock DbContext.
+			var dbContext = new Mock<ApplicationDbContext>();
+
+			// Create a mock DbSet.
+			var dbSet = MockDbSetFactory.Create(myEntities);
+
+			// Set up the MyEntities property so it returns the mocked DbSet.
+			dbContext.Setup(o => o.Plates).Returns(dbSet.Object);
+
+			var platesController = new Catalog.API.Controllers.PlatesController(dbContext.Object);
+
+			var actualResult = await platesController.PurchasePlate(plateId);
+
+			// assert
+			var okResult = Assert.IsType<OkResult>(actualResult);
+			Assert.Equal(200, okResult.StatusCode);
 		}
 
 		private List<Domain.Plate> OrderByGenerator(List<Domain.Plate> plates, string orderBy, bool asc)

--- a/src/Services/Catalog/Catalog.UnitTests/PlatesController.cs
+++ b/src/Services/Catalog/Catalog.UnitTests/PlatesController.cs
@@ -62,7 +62,7 @@ namespace Catalog.UnitTests
 					Registration = x.Registration,
 					PurchasePrice = x.PurchasePrice,
 					SalePrice = x.CalculateSalesPrice(),
-					Reserved = x.IsReserved,
+					Status = x.Status,
 				});
 
 			// assert
@@ -85,7 +85,7 @@ namespace Catalog.UnitTests
 					SalePrice = 8995.00m,
 					Numbers = 44,
 					Letters = "TAG",
-					IsReserved = true
+					Status = PlateStatus.Reserved
 			}, new Domain.Plate() {
 					Id = Guid.Parse("DF81D7FC-319B-46A8-AB66-2574B4169C3D"),
 					Registration = "M44BEY",
@@ -118,13 +118,13 @@ namespace Catalog.UnitTests
 
 			var expectedPlates = myEntities
 				.OrderBy(x => x.Id)
-				.Where(x => !x.IsReserved)
+				.Where(x => x.Status != PlateStatus.Reserved)
 				.Select(x => new
 				{
 					Registration = x.Registration,
 					PurchasePrice = x.PurchasePrice,
 					SalePrice = x.CalculateSalesPrice(),
-					Reserved = x.IsReserved,
+					Status = x.Status,
 				});
 
 			// assert
@@ -184,7 +184,7 @@ namespace Catalog.UnitTests
 					Registration = x.Registration,
 					PurchasePrice = x.PurchasePrice,
 					SalePrice = x.CalculateSalesPrice(),
-					Reserved = x.IsReserved,
+					Status = x.Status,
 				});
 
 			// assert
@@ -213,7 +213,7 @@ namespace Catalog.UnitTests
 					Registration = x.Registration,
 					PurchasePrice = x.PurchasePrice,
 					SalePrice = x.CalculateSalesPrice(),
-					Reserved = x.IsReserved,
+					Status = x.Status,
 				});
 
 
@@ -261,7 +261,7 @@ namespace Catalog.UnitTests
 				   Registration = x.Registration,
 				   PurchasePrice = x.PurchasePrice,
 				   SalePrice = x.CalculateSalesPrice(),
-				   Reserved = x.IsReserved,
+				   Status = x.Status,
 			   });
 
 			// assert
@@ -307,7 +307,7 @@ namespace Catalog.UnitTests
 				   Registration = x.Registration,
 				   PurchasePrice = x.PurchasePrice,
 				   SalePrice = x.CalculateSalesPrice(),
-				   Reserved = x.IsReserved,
+				   Status = x.Status,
 			   });
 
 			// assert
@@ -376,7 +376,7 @@ namespace Catalog.UnitTests
 					Registration = x.Registration,
 					PurchasePrice = x.PurchasePrice,
 					SalePrice = x.CalculateSalesPrice(),
-					Reserved = x.IsReserved,
+					Status = x.Status,
 				});
 
 			// assert
@@ -453,7 +453,7 @@ namespace Catalog.UnitTests
 					Registration = x.Registration,
 					PurchasePrice = x.PurchasePrice,
 					SalePrice = x.CalculateSalesPrice(),
-					Reserved = x.IsReserved,
+					Status = x.Status,
 				});
 
 			// assert
@@ -527,7 +527,7 @@ namespace Catalog.UnitTests
 					SalePrice = 8995.00m,
 					Numbers = 44,
 					Letters = "TAG",
-					IsReserved = true,
+					Status = PlateStatus.Reserved,
 			}, new Domain.Plate() {
 					Id = Guid.Parse("DF81D7FC-319B-46A8-AB66-2574B4169C3D"),
 					Registration = "M44BEY",


### PR DESCRIPTION
Added new endpoint to support plates being sold
New endpoint supports the selling of plates you can sell plates that were reserved
Reserved plates now check if the plate has been sold and has an appropriate error message 
Updated database to use the old Reserved field as a Status field to show if a plate is Available, Reserved or Sold